### PR TITLE
Generating Bias events

### DIFF
--- a/src/tetris/biasEngine/biasEngine.ts
+++ b/src/tetris/biasEngine/biasEngine.ts
@@ -98,10 +98,10 @@ export default class BiasEngine {
 		});
 		this.currentBiasValue = newBiasValue;
 
-		console.log("[profiler] Profile updated.");
-		console.log(profile);
-		console.log("Operating System: " + profile.operatingSystem);
-		console.log("[biasEngine] New bias value calculated:", this.currentBiasValue.toPrecision(3));
+		//console.log("[profiler] Profile updated.");
+		//console.log(profile);
+		//console.log("Operating System: " + profile.operatingSystem);
+		console.log("[biasEngine] New bias value calculated: ", this.currentBiasValue.toPrecision(3));
 	}
 
 	// Profile Bias Values START
@@ -197,7 +197,7 @@ export default class BiasEngine {
 		if(!profile.location.value) {
 			return BiasEngine.positiveBias(0);
 		}
-		const passportValue = PassportValue.instance.getForCountry(profile.location.value.country);
+		const passportValue = PassportValue.instance.getScoreForCountry(profile.location.value.country);
 		const passportValueRange = PassportValue.instance.maxScore - PassportValue.instance.minScore;
 		const factor = (passportValue - PassportValue.instance.minScore) / passportValueRange;
 		return BiasEngine.relativeValueBiasWhereLowerIsBetter(factor);

--- a/src/tetris/biasEngine/biasEngine.ts
+++ b/src/tetris/biasEngine/biasEngine.ts
@@ -12,6 +12,7 @@ import Gender from "tetris/profiler/profileValues/gender";
 import PassportValue from "tetris/biasEngine/datasources/PassportValue";
 import OperatingSystem from "tetris/profiler/profileValues/OperatingSystem";
 import BiasEventGenerator from "tetris/biasEngine/biasEventGenerator";
+import Utility from "tetris/utility";
 
 interface CalculateBiasForProfileData {
 	(profile: Profile): number
@@ -87,7 +88,7 @@ export default class BiasEngine {
 	//region private methods
 	// @ts-ignore
 	private set currentBiasValue(value: number) {
-		this._currentBiasValue = Math.min(BiasEngine.MAX_POSITIVE_BIAS_VALUE, Math.max(BiasEngine.MAX_NEGATIVE_BIAS_VALUE, value));
+		this._currentBiasValue = Utility.limitValueBetweenMinAndMax(value, BiasEngine.MAX_NEGATIVE_BIAS_VALUE, BiasEngine.MAX_POSITIVE_BIAS_VALUE);
 	}
 
 	private _onProfileUpdate(profile: Profile): void {
@@ -98,20 +99,17 @@ export default class BiasEngine {
 		});
 		this.currentBiasValue = newBiasValue;
 
-		//console.log("[profiler] Profile updated.");
-		//console.log(profile);
-		//console.log("Operating System: " + profile.operatingSystem);
 		console.log("[biasEngine] New bias value calculated: ", this.currentBiasValue.toPrecision(3));
 	}
 
 	// Profile Bias Values START
 	private static positiveBias(factor: number): number {
-		factor = Math.min(1, Math.max(0, factor));
+		factor = Utility.limitValueBetweenMinAndMax(factor, 0.0, 1.0);
 		return (BiasEngine.MAX_POSITIVE_BIAS_VALUE - BiasEngine.NEUTRAL_BIAS_VALUE) * factor;
 	}
 
 	private static negativeBias(factor: number): number {
-		factor = Math.min(1, Math.max(0, factor));
+		factor = Utility.limitValueBetweenMinAndMax(factor, 0.0, 1.0);
 		return (BiasEngine.MAX_NEGATIVE_BIAS_VALUE - BiasEngine.NEUTRAL_BIAS_VALUE) * factor;
 	}
 

--- a/src/tetris/biasEngine/biasEvent.ts
+++ b/src/tetris/biasEngine/biasEvent.ts
@@ -1,10 +1,24 @@
 /// <reference path="../../../definitions/phaser.d.ts"/>
 
 import BiasEventType from "tetris/biasEngine/biasEventType"
+import BiasEventGenerator from "tetris/biasEngine/biasEventGenerator";
+import BiasEngine from "tetris/biasEngine/biasEngine";
 
-export default class BiasEvent {
+export default abstract class BiasEvent {
 
 	//region public members
+	public get minDuration(): number {
+		return 1.0;
+	}
+
+	public get maxDuration(): number {
+		return 5.0;
+	}
+
+	public get durationRange(): number {
+		return this.maxDuration - this.minDuration;
+	}
+
 	public get eventType(): BiasEventType {
 		return this._eventType;
 	}
@@ -16,25 +30,121 @@ export default class BiasEvent {
 	public get endTime(): number {
 		return this._endTime;
 	}
+
+	public get totalDetectionLevelIncrease(): number {
+		return (this.endTime - this.startTime) * this._detectionLevelIncreasePerSecond;
+	}
+
+	public get isActive(): boolean {
+		const now = Date.now();
+
+		if (now < this.startTime) {
+			return false;
+		}
+		else if (now > this.endTime) {
+			return false;
+		}
+
+		return true;
+	}
 	//endregion
 
 	//region public methods
+	public initializeFromPrototype(detectionLevelDelta: number): BiasEvent {
+		const now = Date.now();
+		let clone = this._clone();
+
+		const duration = this.durationRange * (detectionLevelDelta / this._detectionLevelIncreasePerSecond);
+		clone._startTime = now;
+		clone._endTime = now + Math.max(this.minDuration, Math.min(this.maxDuration, duration));
+
+		return clone;
+	}
+
+	public calculateSpawnProbability(currentBias: number) {
+		const relativeBias = currentBias - BiasEngine.NEUTRAL_BIAS_VALUE;
+		const relativeThreshold = this._spawnBiasThreshold - BiasEngine.NEUTRAL_BIAS_VALUE;
+
+		if (relativeBias == 0) {
+			return 0.0;
+		}
+
+		if (!this._haveSameSign(relativeBias, relativeThreshold)) {
+			return 0.0;
+		}
+
+		if (Math.abs(relativeBias) >= Math.abs(relativeThreshold)) {
+			return 1.0;
+		}
+
+		return Math.abs(relativeThreshold) / Math.abs(relativeBias);
+	}
+
+	public calculateDetectionLevelDecrease(deltaInSeconds: number): number {
+		return deltaInSeconds * this._detectionLevelDecreasePerSecond;
+	}
 	//endregion
 
 	//region constructor
-	public constructor(biasEventType: BiasEventType, startTime: number, endTime: number) {
+	protected constructor(biasEventType: BiasEventType) {
 		this._eventType = biasEventType;
-		this._startTime = startTime;
-		this._endTime = endTime;
 	}
 	//endregion
 
 	//region private members
 	private readonly _eventType: BiasEventType;
-	private readonly _startTime: number;
-	private readonly _endTime: number;
+	private _startTime: number;
+	private _endTime: number;
 	//endregion
 
 	//region private methods
+	private _haveSameSign(value1: number, value2: number): boolean {
+		if (value1 >= 0 && value2 >= 0) {
+			return true;
+		}
+		else if (value1 < 0 && value2 < 0) {
+			return true;
+		}
+
+		return false;
+	}
+	//endregion
+
+	//region protected members
+	protected _detectionLevelIncreasePerSecond: number = BiasEventGenerator.DETECTION_LEVEL_RANGE * 0.05;
+	protected _detectionLevelDecreasePerSecond: number = BiasEventGenerator.DETECTION_LEVEL_RANGE * 0.025;
+	protected _spawnBiasThreshold: number = BiasEngine.NEUTRAL_BIAS_VALUE;
+	//endregion
+
+	//region protected methods
+	protected _clone(): BiasEvent {
+		let event = this._createNewInstance();
+		event._detectionLevelIncreasePerSecond = this._detectionLevelIncreasePerSecond;
+		event._detectionLevelDecreasePerSecond = this._detectionLevelDecreasePerSecond;
+		event._startTime = 0;
+		event._endTime = 0;
+
+		return event;
+	}
+
+	protected abstract _createNewInstance(): BiasEvent;
+
+	protected _setDetectionLevelIncreasePerSecond(factor: number): void {
+		this._detectionLevelIncreasePerSecond = BiasEventGenerator.DETECTION_LEVEL_RANGE * factor;
+	}
+
+	protected _setDetectionLevelDecreasePerSecond(factor: number): void {
+		this._detectionLevelDecreasePerSecond = BiasEventGenerator.DETECTION_LEVEL_RANGE * factor;
+	}
+
+	protected _setNegativeSpawnBiasThreshold(factor: number): void {
+		const range = BiasEngine.MAX_NEGATIVE_BIAS_VALUE - BiasEngine.NEUTRAL_BIAS_VALUE;
+		this._spawnBiasThreshold = BiasEngine.NEUTRAL_BIAS_VALUE - factor * range;
+	}
+
+	protected _setPositiveSpawnBiasThreshold(factor: number): void {
+		const range = BiasEngine.MAX_POSITIVE_BIAS_VALUE - BiasEngine.NEUTRAL_BIAS_VALUE;
+		this._spawnBiasThreshold = BiasEngine.NEUTRAL_BIAS_VALUE + factor * range;
+	}
 	//endregion
 }

--- a/src/tetris/biasEngine/biasEvent.ts
+++ b/src/tetris/biasEngine/biasEvent.ts
@@ -70,7 +70,7 @@ export default abstract class BiasEvent {
 			return 0.0;
 		}
 
-		if (!this._haveSameSign(relativeBias, relativeThreshold)) {
+		if (!Utility.haveSameSign(relativeBias, relativeThreshold)) {
 			return 0.0;
 		}
 
@@ -99,16 +99,6 @@ export default abstract class BiasEvent {
 	//endregion
 
 	//region private methods
-	private _haveSameSign(value1: number, value2: number): boolean {
-		if (value1 >= 0 && value2 >= 0) {
-			return true;
-		}
-		else if (value1 < 0 && value2 < 0) {
-			return true;
-		}
-
-		return false;
-	}
 	//endregion
 
 	//region protected members

--- a/src/tetris/biasEngine/biasEvent.ts
+++ b/src/tetris/biasEngine/biasEvent.ts
@@ -7,16 +7,16 @@ import BiasEngine from "tetris/biasEngine/biasEngine";
 export default abstract class BiasEvent {
 
 	//region public members
-	public get minDuration(): number {
-		return 1.0;
+	public get minDurationInMs(): number {
+		return 3000;
 	}
 
-	public get maxDuration(): number {
-		return 5.0;
+	public get maxDurationInMs(): number {
+		return 6000;
 	}
 
 	public get durationRange(): number {
-		return this.maxDuration - this.minDuration;
+		return this.maxDurationInMs - this.minDurationInMs;
 	}
 
 	public get eventType(): BiasEventType {
@@ -32,7 +32,7 @@ export default abstract class BiasEvent {
 	}
 
 	public get totalDetectionLevelIncrease(): number {
-		return (this.endTime - this.startTime) * this._detectionLevelIncreasePerSecond;
+		return ((this.endTime - this.startTime) / 1000.0) * this._detectionLevelIncreasePerSecond;
 	}
 
 	public get isActive(): boolean {
@@ -51,12 +51,12 @@ export default abstract class BiasEvent {
 
 	//region public methods
 	public initializeFromPrototype(detectionLevelDelta: number): BiasEvent {
-		const now = Date.now();
 		let clone = this._clone();
-
 		const duration = this.durationRange * (detectionLevelDelta / this._detectionLevelIncreasePerSecond);
+
+		const now = Date.now();
 		clone._startTime = now;
-		clone._endTime = now + Math.max(this.minDuration, Math.min(this.maxDuration, duration));
+		clone._endTime = now + Math.max(this.minDurationInMs, Math.min(this.maxDurationInMs, duration));
 
 		return clone;
 	}
@@ -80,8 +80,8 @@ export default abstract class BiasEvent {
 		return Math.abs(relativeThreshold) / Math.abs(relativeBias);
 	}
 
-	public calculateDetectionLevelDecrease(deltaInSeconds: number): number {
-		return deltaInSeconds * this._detectionLevelDecreasePerSecond;
+	public calculateDetectionLevelDecrease(deltaInMs: number): number {
+		return (deltaInMs / 1000.0) * this._detectionLevelDecreasePerSecond;
 	}
 	//endregion
 
@@ -139,7 +139,7 @@ export default abstract class BiasEvent {
 
 	protected _setNegativeSpawnBiasThreshold(factor: number): void {
 		const range = BiasEngine.MAX_NEGATIVE_BIAS_VALUE - BiasEngine.NEUTRAL_BIAS_VALUE;
-		this._spawnBiasThreshold = BiasEngine.NEUTRAL_BIAS_VALUE - factor * range;
+		this._spawnBiasThreshold = BiasEngine.NEUTRAL_BIAS_VALUE + factor * range;
 	}
 
 	protected _setPositiveSpawnBiasThreshold(factor: number): void {

--- a/src/tetris/biasEngine/biasEvent.ts
+++ b/src/tetris/biasEngine/biasEvent.ts
@@ -3,6 +3,7 @@
 import BiasEventType from "tetris/biasEngine/biasEventType"
 import BiasEventGenerator from "tetris/biasEngine/biasEventGenerator";
 import BiasEngine from "tetris/biasEngine/biasEngine";
+import Utility from "tetris/utility";
 
 export default abstract class BiasEvent {
 
@@ -56,7 +57,7 @@ export default abstract class BiasEvent {
 
 		const now = Date.now();
 		clone._startTime = now;
-		clone._endTime = now + Math.max(this.minDurationInMs, Math.min(this.maxDurationInMs, duration));
+		clone._endTime = now + Utility.limitValueBetweenMinAndMax(duration, this.minDurationInMs, this.maxDurationInMs);
 
 		return clone;
 	}

--- a/src/tetris/biasEngine/biasEventGenerator.ts
+++ b/src/tetris/biasEngine/biasEventGenerator.ts
@@ -1,0 +1,143 @@
+import BiasEngine from "tetris/biasEngine/biasEngine";
+import BiasEvent from "tetris/biasEngine/biasEvent";
+import BiasEventDisableInput from "tetris/biasEngine/events/biasEventDisableInput";
+import BiasEventDuplicateInput from "tetris/biasEngine/events/biasEventDuplicateInput";
+import BiasEventReceiver from "tetris/biasEngine/biasEventReceiver";
+
+export default class BiasEventGenerator {
+    //region public members
+    public static get MAX_DETECTION_LEVEL(): number {
+        return 1.0;
+    }
+
+    public static get MIN_DETECTION_LEVEL(): number {
+        return 0.0;
+    }
+
+    public static get DETECTION_LEVEL_RANGE(): number {
+        return BiasEventGenerator.MAX_DETECTION_LEVEL - BiasEventGenerator.MIN_DETECTION_LEVEL;
+    }
+    //endregion
+
+    //region public methods
+    public update(time: number, delta: number): void {
+    	const currentBias = this._biasEngine.currentBiasValue;
+    	this._decreaseDetectionLevel(delta);
+    	const targetDetectionLevel = this._calculateTargetDetectionLevel(currentBias);
+
+    	if (!this._readyForBiasEvent(targetDetectionLevel)) {
+    		return;
+	    }
+
+	    const eventPrototype = this._selectEventPrototype();
+    	const event = eventPrototype.initializeFromPrototype(targetDetectionLevel - this.currentDetectionLevel);
+    	this.currentDetectionLevel += event.totalDetectionLevelIncrease;
+    	this._sendBiasEvent(event);
+    }
+
+	public newEventReceiver(): BiasEventReceiver {
+		const receiver = new BiasEventReceiver();
+		this._biasEventReceivers.push(receiver);
+
+		return receiver;
+	}
+    //endregion
+
+    //region constructor
+	public constructor(biasEngine: BiasEngine) {
+    	this._biasEngine = biasEngine;
+    	this._biasEventPrototypes = [
+    		new BiasEventDisableInput(),
+		    new BiasEventDuplicateInput(),
+		]
+	}
+    //endregion
+
+    //region private members
+	private readonly _minBiasEventIntervalInMs = 10000;
+	private readonly _biasEngine: BiasEngine;
+	private readonly _biasEventPrototypes: BiasEvent[];
+	private readonly _biasEventReceivers: BiasEventReceiver[] = [];
+    private _detectionLevel: number;
+
+    private _latestBiasEvent: BiasEvent;
+
+    private get currentDetectionLevel(): number {
+        return this._detectionLevel;
+    }
+
+    private set currentDetectionLevel(level: number) {
+        this._detectionLevel = Math.max(BiasEventGenerator.MIN_DETECTION_LEVEL, Math.min(BiasEventGenerator.MAX_DETECTION_LEVEL, level));
+    }
+    //endregion
+
+    //region private methods
+	private _decreaseDetectionLevel(deltaInSeconds: number): void {
+    	let decrease = this._calculateFallbackDetectionLevelDecrease(deltaInSeconds);
+    	if (this._latestBiasEvent) {
+    		decrease = this._latestBiasEvent.calculateDetectionLevelDecrease(deltaInSeconds);
+	    }
+
+	    this.currentDetectionLevel = this.currentDetectionLevel - decrease;
+	}
+
+	private _calculateFallbackDetectionLevelDecrease(deltaInSeconds: number): number {
+    	return BiasEventGenerator.DETECTION_LEVEL_RANGE * 0.05 * deltaInSeconds;
+	}
+
+	private _calculateTargetDetectionLevel(currentBias: number): number {
+    	const relativeBias = currentBias - BiasEngine.NEUTRAL_BIAS_VALUE;
+    	let targetDetectionLevel = 0.25 /* offset */ + Math.min(0.8, relativeBias) * 0.75;
+    	return Math.max(BiasEventGenerator.MIN_DETECTION_LEVEL, Math.min(BiasEventGenerator.MAX_DETECTION_LEVEL, targetDetectionLevel));
+	}
+
+	private _readyForBiasEvent(targetDetectionLevel: number): boolean {
+    	if (this.currentDetectionLevel > targetDetectionLevel) {
+    		return false;
+	    }
+
+	    if (this._latestBiasEvent && this._latestBiasEvent.isActive) {
+	    	return false;
+	    }
+
+	    if (Date.now() < this._latestBiasEvent.endTime + this._minBiasEventIntervalInMs) {
+	    	return false;
+	    }
+
+	    return true;
+	}
+
+	private _selectEventPrototype(): BiasEvent {
+    	const currentBias = this._biasEngine.currentBiasValue;
+		const spawnProbabilities = [];
+		let totalSpawnProbability = 0.0;
+
+		this._biasEventPrototypes.forEach(prototype => {
+			const probability = prototype.calculateSpawnProbability(currentBias);
+
+			if (probability <= 0.0) {
+				return;
+			}
+			spawnProbabilities.push([probability, prototype]);
+			totalSpawnProbability += probability;
+		});
+
+		let random = Math.random();
+		for (let i = 0; i < spawnProbabilities.length; ++i) {
+			const normalizedProbability = spawnProbabilities[i][0] / totalSpawnProbability;
+
+			if (normalizedProbability < random) {
+				random -= normalizedProbability;
+				continue;
+			}
+
+			return spawnProbabilities[i][1];
+		}
+	}
+
+	private _sendBiasEvent(event: BiasEvent): void {
+    	console.log("sending bias event: " + event);
+		this._biasEventReceivers.forEach((eventReceiver) => eventReceiver.receiveEvent(event));
+	}
+    //endregion
+}

--- a/src/tetris/biasEngine/biasEventGenerator.ts
+++ b/src/tetris/biasEngine/biasEventGenerator.ts
@@ -3,6 +3,7 @@ import BiasEvent from "tetris/biasEngine/biasEvent";
 import BiasEventDisableInput from "tetris/biasEngine/events/biasEventDisableInput";
 import BiasEventDuplicateInput from "tetris/biasEngine/events/biasEventDuplicateInput";
 import BiasEventReceiver from "tetris/biasEngine/biasEventReceiver";
+import Utility from "tetris/utility";
 
 export default class BiasEventGenerator {
     //region public members
@@ -77,7 +78,7 @@ export default class BiasEventGenerator {
     }
 
     private set currentDetectionLevel(level: number) {
-        this._detectionLevel = Math.max(BiasEventGenerator.MIN_DETECTION_LEVEL, Math.min(BiasEventGenerator.MAX_DETECTION_LEVEL, level));
+    	this._detectionLevel = Utility.limitValueBetweenMinAndMax(level, BiasEventGenerator.MIN_DETECTION_LEVEL, BiasEventGenerator.MAX_DETECTION_LEVEL);
     }
     //endregion
 
@@ -99,7 +100,7 @@ export default class BiasEventGenerator {
 	private _calculateTargetDetectionLevel(currentBias: number): number {
     	const relativeBias = currentBias - BiasEngine.NEUTRAL_BIAS_VALUE;
     	let targetDetectionLevel = 0.25 /* offset */ + Math.min(0.8, relativeBias) * 0.75;
-    	return Math.max(BiasEventGenerator.MIN_DETECTION_LEVEL, Math.min(BiasEventGenerator.MAX_DETECTION_LEVEL, targetDetectionLevel));
+    	return Utility.limitValueBetweenMinAndMax(targetDetectionLevel, BiasEventGenerator.MIN_DETECTION_LEVEL, BiasEventGenerator.MAX_DETECTION_LEVEL);
 	}
 
 	private _readyForBiasEvent(targetDetectionLevel: number): boolean {

--- a/src/tetris/biasEngine/biasEventReceiver.ts
+++ b/src/tetris/biasEngine/biasEventReceiver.ts
@@ -16,7 +16,7 @@ export default class BiasEventReceiver {
 
 	//region public methods
 	public update(time: number, delta: number): void {
-		this._removeExpiredEvents(time);
+		this._removeExpiredEvents();
 		this._triggerEventCallbacks();
 	}
 
@@ -43,7 +43,15 @@ export default class BiasEventReceiver {
 	}
 
 	public has(eventType: BiasEventType): boolean {
-		return this._events.has(eventType);
+		if (!this._events.has(eventType)) {
+			return false;
+		}
+
+		if (!this._events.get(eventType).isActive) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public get(eventType: BiasEventType): BiasEvent {
@@ -51,7 +59,7 @@ export default class BiasEventReceiver {
 			return null;
 		}
 
-		return this._events[eventType];
+		return this._events.get(eventType);
 	}
 	//endregion
 
@@ -69,9 +77,10 @@ export default class BiasEventReceiver {
 	//endregion
 
 	//region private methods
-	private _removeExpiredEvents(time: number): void {
+	private _removeExpiredEvents(): void {
+		const now = Date.now();
 		this._events.forEach((value: BiasEvent, key: BiasEventType) => {
-			if (value.endTime >= time) {
+			if (value.endTime >= now) {
 				return;
 			}
 

--- a/src/tetris/biasEngine/events/biasEventDisableInput.ts
+++ b/src/tetris/biasEngine/events/biasEventDisableInput.ts
@@ -1,19 +1,38 @@
 import BiasEvent from "tetris/biasEngine/biasEvent";
+import BiasEventType from "tetris/biasEngine/biasEventType";
 
 export default class BiasEventDisableInput extends BiasEvent {
 
 	//region public members
+	public get maxDuration(): number {
+		return 2.5;
+	}
 	//endregion
 
 	//region public methods
 	//endregion
 
 	//region constructor
+	public constructor() {
+		super(BiasEventType.DisableInput);
+		this._setDetectionLevelIncreasePerSecond(0.1);
+		this._setDetectionLevelDecreasePerSecond(0.025);
+		this._setNegativeSpawnBiasThreshold(0.75);
+	}
 	//endregion
 
 	//region private members
 	//endregion
 
 	//region private methods
+	//endregion
+
+	//region protected members
+	//endregion
+
+	//region protected methods
+	protected _createNewInstance(): BiasEventDisableInput {
+		return new BiasEventDisableInput();
+	}
 	//endregion
 }

--- a/src/tetris/biasEngine/events/biasEventDisableInput.ts
+++ b/src/tetris/biasEngine/events/biasEventDisableInput.ts
@@ -4,9 +4,6 @@ import BiasEventType from "tetris/biasEngine/biasEventType";
 export default class BiasEventDisableInput extends BiasEvent {
 
 	//region public members
-	public get maxDuration(): number {
-		return 2.5;
-	}
 	//endregion
 
 	//region public methods
@@ -15,7 +12,7 @@ export default class BiasEventDisableInput extends BiasEvent {
 	//region constructor
 	public constructor() {
 		super(BiasEventType.DisableInput);
-		this._setDetectionLevelIncreasePerSecond(0.1);
+		this._setDetectionLevelIncreasePerSecond(0.15);
 		this._setDetectionLevelDecreasePerSecond(0.025);
 		this._setNegativeSpawnBiasThreshold(0.75);
 	}

--- a/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
+++ b/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
@@ -1,5 +1,6 @@
 import BiasEvent from "tetris/biasEngine/biasEvent";
 import BiasEventType from "tetris/biasEngine/biasEventType";
+import Utility from "tetris/utility";
 
 export default class BiasEventDuplicateInput extends BiasEvent {
 
@@ -9,7 +10,7 @@ export default class BiasEventDuplicateInput extends BiasEvent {
 	}
 
 	public set chance(chance: number) {
-		this._chance = Math.min(1.0, Math.max(0.0, chance));
+		this._chance = Utility.limitValueBetweenMinAndMax(chance, 0.0, 1.0);
 	}
 	//endregion
 

--- a/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
+++ b/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
@@ -19,6 +19,9 @@ export default class BiasEventDuplicateInput extends BiasEvent {
 	//region constructor
 	public constructor() {
 		super(BiasEventType.DuplicateInput);
+		this._setDetectionLevelIncreasePerSecond(0.1);
+		this._setDetectionLevelDecreasePerSecond(0.035);
+		this._setNegativeSpawnBiasThreshold(0.5);
 	}
 	//endregion
 

--- a/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
+++ b/src/tetris/biasEngine/events/biasEventDuplicateInput.ts
@@ -9,7 +9,7 @@ export default class BiasEventDuplicateInput extends BiasEvent {
 	}
 
 	public set chance(chance: number) {
-		this._chance = Math.min(1, Math.abs(chance));
+		this._chance = Math.min(1.0, Math.max(0.0, chance));
 	}
 	//endregion
 
@@ -17,16 +17,31 @@ export default class BiasEventDuplicateInput extends BiasEvent {
 	//endregion
 
 	//region constructor
-	public constructor(startTime: number, endTime: number, duplicateChance: number = 1.0) {
-		super(BiasEventType.DuplicateInput, startTime, endTime);
-		this.chance = duplicateChance;
+	public constructor() {
+		super(BiasEventType.DuplicateInput);
 	}
 	//endregion
 
 	//region private members
-	private _chance: number;
+	private _chance: number = 1.0;
 	//endregion
 
 	//region private methods
+	//endregion
+
+	//region protected members
+	//endregion
+
+	//region protected methods
+	protected _clone(): BiasEvent {
+		let event = super._clone() as BiasEventDuplicateInput;
+		event._chance = this.chance;
+
+		return event;
+	}
+
+	protected _createNewInstance(): BiasEventDuplicateInput {
+		return new BiasEventDuplicateInput();
+	}
 	//endregion
 }

--- a/src/tetris/player/localPlayer.ts
+++ b/src/tetris/player/localPlayer.ts
@@ -14,8 +14,6 @@ export default class LocalPlayer extends Player {
 
 	//region public methods
 	public update(time: number, delta: number): void {
-		// update bias events
-		this._biasEventReceiver.update(time, delta);
 		// apply bias
 		if (this._biasEventReceiver.has(BiasEventType.DisableInput)) {
 			return;
@@ -64,7 +62,7 @@ export default class LocalPlayer extends Player {
 			return;
 		}
 		const biasEvent = this._biasEventReceiver.get(BiasEventType.DuplicateInput) as BiasEventDuplicateInput;
-		if (biasEvent.chance <= Math.random()) {
+		if (biasEvent.chance >= Math.random()) {
 			moveOperation();
 		}
 	}

--- a/src/tetris/profiler/baseProfileData.ts
+++ b/src/tetris/profiler/baseProfileData.ts
@@ -1,4 +1,5 @@
 import ProfileDataConfidenceStrategy from "tetris/profiler/confidenceStrategy/profileDataConfidenceStrategy";
+import Utility from "tetris/utility";
 
 export default class BaseProfileData {
 
@@ -28,7 +29,7 @@ export default class BaseProfileData {
 	}
 
 	public set confidence(confidence: number) {
-		this._confidence = Math.min(BaseProfileData.MAX_CONFIDENCE, Math.max(BaseProfileData.MIN_CONFIDENCE, confidence));
+		this._confidence = Utility.limitValueBetweenMinAndMax(confidence, BaseProfileData.MIN_CONFIDENCE, BaseProfileData.MAX_CONFIDENCE);
 	}
 
 	public get confidenceStrategy(): ProfileDataConfidenceStrategy {

--- a/src/tetris/profiler/hardwareController/cameraController.ts
+++ b/src/tetris/profiler/hardwareController/cameraController.ts
@@ -44,7 +44,7 @@ export default class CameraController {
 			return stream;
 		} catch(reason) {
 			this._permissionState = HardwarePermission.denied;
-			//console.log('Can not start video stream. Message: ' + reason);
+			console.log('Can not start video stream. Message: ' + reason);
 			throw reason;
 		}
 	}
@@ -120,7 +120,6 @@ export default class CameraController {
 		const base64Image = this._canvas
 			.toDataURL('image/png')
 			.replace(/^data:image\/(png|jpg);base64,/, "");
-		//console.log('Snapshot taken: ' + base64Image.substr(base64Image.length - 20));
 		return base64Image;
 	}
 

--- a/src/tetris/profiler/hardwareController/cameraController.ts
+++ b/src/tetris/profiler/hardwareController/cameraController.ts
@@ -44,7 +44,7 @@ export default class CameraController {
 			return stream;
 		} catch(reason) {
 			this._permissionState = HardwarePermission.denied;
-			console.log('Can not start video stream. Message: ' + reason);
+			//console.log('Can not start video stream. Message: ' + reason);
 			throw reason;
 		}
 	}
@@ -120,7 +120,7 @@ export default class CameraController {
 		const base64Image = this._canvas
 			.toDataURL('image/png')
 			.replace(/^data:image\/(png|jpg);base64,/, "");
-		console.log('Snapshot taken: ' + base64Image.substr(base64Image.length - 20));
+		//console.log('Snapshot taken: ' + base64Image.substr(base64Image.length - 20));
 		return base64Image;
 	}
 

--- a/src/tetris/profiler/profiler.ts
+++ b/src/tetris/profiler/profiler.ts
@@ -157,7 +157,7 @@ export default class Profiler {
 
 	// ERROR callbacks
 	private static _handleServiceError(senderName: string, error: Error): void {
-		//console.log(senderName + " ==> " + error);
+		console.log(senderName + " ==> " + error);
 	}
 	//endregion
 }

--- a/src/tetris/profiler/profiler.ts
+++ b/src/tetris/profiler/profiler.ts
@@ -157,7 +157,7 @@ export default class Profiler {
 
 	// ERROR callbacks
 	private static _handleServiceError(senderName: string, error: Error): void {
-		console.log(senderName + " ==> " + error);
+		//console.log(senderName + " ==> " + error);
 	}
 	//endregion
 }

--- a/src/tetris/profiler/service/baseService.ts
+++ b/src/tetris/profiler/service/baseService.ts
@@ -21,7 +21,6 @@ export default abstract class BaseService {
 		}
 		this._hasBeenStarted = true;
 		await this._run(successCallback);
-		//console.log('Service ' + this.name + ' has been activated');
 	}
 	//endregion
 

--- a/src/tetris/profiler/service/baseService.ts
+++ b/src/tetris/profiler/service/baseService.ts
@@ -21,7 +21,7 @@ export default abstract class BaseService {
 		}
 		this._hasBeenStarted = true;
 		await this._run(successCallback);
-		console.log('Service ' + this.name + ' has been activated');
+		//console.log('Service ' + this.name + ' has been activated');
 	}
 	//endregion
 

--- a/src/tetris/profiler/updateStrategy/numberDataUpdateStrategy.ts
+++ b/src/tetris/profiler/updateStrategy/numberDataUpdateStrategy.ts
@@ -1,6 +1,7 @@
 import ProfileDataUpdateStrategy from "tetris/profiler/updateStrategy/profileDataUpdateStrategy";
 import ProfileData from "tetris/profiler/profileData";
 import BaseProfileData from "tetris/profiler/baseProfileData";
+import Utility from "tetris/utility";
 
 export default class NumberDataUpdateStrategy extends ProfileDataUpdateStrategy<number> {
 
@@ -10,7 +11,7 @@ export default class NumberDataUpdateStrategy extends ProfileDataUpdateStrategy<
 	}
 
 	public set latestValueWeight(weight: number) {
-		this._latestValueWeight = Math.min(1, Math.max(0, Math.abs(weight)));
+		this._latestValueWeight = Utility.limitValueBetweenMinAndMax(Math.abs(weight), 0.0, 1.0);
 	}
 	//endregion
 

--- a/src/tetris/scene/playScene.ts
+++ b/src/tetris/scene/playScene.ts
@@ -151,11 +151,9 @@ export default class PlayScene extends Phaser.Scene {
 	//region private methods
 	private _setupNetworkingClient(): void {
 		this._game.networkingClient.receive("playerLeft", (args) => {
-			//console.log('playerLeft:', args.id);
 			this._removeRemoteField(args.id);
 		});
 		this._game.networkingClient.receive("playerJoined", (args) => {
-			//console.log('playerJoined:', args.id);
 			this._addRemoteField(args.id);
 		});
 		this._game.networkingClient.receive("fieldUpdate", (args) => {
@@ -167,7 +165,6 @@ export default class PlayScene extends Phaser.Scene {
 			field.updateSprites(args.fieldState);
 		});
 		this._game.networkingClient.receive("currentPlayers", (args) => {
-			//console.log("Received currentPlayers");
 			args.players.forEach(player => {
 				this._addRemoteField(player);
 				this._remotePlayerFields.get(player).updateSprites(args.fields[player]);

--- a/src/tetris/scene/playScene.ts
+++ b/src/tetris/scene/playScene.ts
@@ -151,11 +151,11 @@ export default class PlayScene extends Phaser.Scene {
 	//region private methods
 	private _setupNetworkingClient(): void {
 		this._game.networkingClient.receive("playerLeft", (args) => {
-			console.log('playerLeft:', args.id);
+			//console.log('playerLeft:', args.id);
 			this._removeRemoteField(args.id);
 		});
 		this._game.networkingClient.receive("playerJoined", (args) => {
-			console.log('playerJoined:', args.id);
+			//console.log('playerJoined:', args.id);
 			this._addRemoteField(args.id);
 		});
 		this._game.networkingClient.receive("fieldUpdate", (args) => {
@@ -167,7 +167,7 @@ export default class PlayScene extends Phaser.Scene {
 			field.updateSprites(args.fieldState);
 		});
 		this._game.networkingClient.receive("currentPlayers", (args) => {
-			console.log("Received currentPlayers");
+			//console.log("Received currentPlayers");
 			args.players.forEach(player => {
 				this._addRemoteField(player);
 				this._remotePlayerFields.get(player).updateSprites(args.fields[player]);

--- a/src/tetris/utility.ts
+++ b/src/tetris/utility.ts
@@ -3,6 +3,10 @@ export default class Utility {
 	public static limitValueBetweenMinAndMax(value: number, min: number, max: number): number {
 		return Math.max(min, Math.min(max, value));
 	}
+
+	public static haveSameSign(value1: number, value2: number): boolean {
+		return value1 * value2 >= 0;
+	}
 	//endregion
 
 	//region public members

--- a/src/tetris/utility.ts
+++ b/src/tetris/utility.ts
@@ -1,0 +1,19 @@
+export default class Utility {
+	//region public methods
+	public static limitValueBetweenMinAndMax(value: number, min: number, max: number): number {
+		return Math.max(min, Math.min(max, value));
+	}
+	//endregion
+
+	//region public members
+	//endregion
+
+	//region constructor
+	//endregion
+
+	//region private members
+	//endregion
+
+	//region private methods
+	//endregion
+}


### PR DESCRIPTION
This PR introduces the `BiasEventGenerator`, which is part of the `BiasEngine`.
The `BiasEventGenerator` is responsible for tracking the user's overall awareness of being biased and generating `BiasEvents` at the right times.
In order to find the right timing for generating such events, the `BiasEvent` class has been extended to allow for estimating the detection probability of the user.